### PR TITLE
Add support for Spark v1.6.2

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -15,10 +15,10 @@ COPY bde-spark.css /css/org/apache/spark/ui/static/timeline-view.css
 RUN apt-get update \
       && apt-get install -y curl \
       && chmod +x *.sh \
-      && wget http://d3kbcqa49mib13.cloudfront.net/spark-1.5.1-bin-hadoop2.6.tgz \
-      && tar -xvzf spark-1.5.1-bin-hadoop2.6.tgz \
-      && mv spark-1.5.1-bin-hadoop2.6 spark \
-      && rm spark-1.5.1-bin-hadoop2.6.tgz \
+      && wget http://d3kbcqa49mib13.cloudfront.net/spark-1.6.2-bin-hadoop2.6.tgz \
+      && tar -xvzf spark-1.6.2-bin-hadoop2.6.tgz \
+      && mv spark-1.6.2-bin-hadoop2.6 spark \
+      && rm spark-1.6.2-bin-hadoop2.6.tgz \
       && cd /css \
-      && jar uf /spark/lib/spark-assembly-1.5.1-hadoop2.6.0.jar org/apache/spark/ui/static/timeline-view.css \
+      && jar uf /spark/lib/spark-assembly-1.6.2-hadoop2.6.0.jar org/apache/spark/ui/static/timeline-view.css \
       && cd /

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,4 +1,4 @@
-FROM bde2020/spark-base:1.5.1-hadoop2.6
+FROM bde2020/spark-base:1.6.2-hadoop2.6
 
 MAINTAINER Erika Pauwels <erika.pauwels@tenforce.com>
 

--- a/master/master.sh
+++ b/master/master.sh
@@ -8,5 +8,7 @@ export SPARK_MASTER_IP=`hostname`
 
 mkdir -p $SPARK_MASTER_LOG
 
-/spark/sbin/../bin/spark-class org.apache.spark.deploy.master.Master \
+export SPARK_HOME=/spark
+
+cd /spark/bin && /spark/sbin/../bin/spark-class org.apache.spark.deploy.master.Master \
     --ip $SPARK_MASTER_IP --port $SPARK_MASTER_PORT --webui-port $SPARK_MASTER_WEBUI_PORT >> $SPARK_MASTER_LOG/spark-master.out

--- a/submit/Dockerfile
+++ b/submit/Dockerfile
@@ -1,4 +1,4 @@
-FROM bde2020/spark-base:1.5.1-hadoop2.6
+FROM bde2020/spark-base:1.6.2-hadoop2.6
 
 MAINTAINER Erika Pauwels <erika.pauwels@tenforce.com>
 

--- a/submit/submit.sh
+++ b/submit/submit.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 export SPARK_MASTER_URL=spark://${SPARK_MASTER_NAME}:${SPARK_MASTER_PORT}
+export SPARK_HOME=/spark
 
 /wait-for-step.sh
 

--- a/template/java/Dockerfile
+++ b/template/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM bde2020/spark-submit:1.5.1-hadoop2.6
+FROM bde2020/spark-submit:1.6.2-hadoop2.6
 
 MAINTAINER Erika Pauwels <erika.pauwels@tenforce.com>
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM bde2020/spark-base:1.5.1-hadoop2.6
+FROM bde2020/spark-base:1.6.2-hadoop2.6
 
 MAINTAINER Erika Pauwels <erika.pauwels@tenforce.com>
 

--- a/worker/worker.sh
+++ b/worker/worker.sh
@@ -6,6 +6,8 @@
 
 mkdir -p $SPARK_WORKER_LOG
 
+export SPARK_HOME=/spark
+
 /spark/sbin/../bin/spark-class org.apache.spark.deploy.worker.Worker \
     --webui-port $SPARK_WORKER_WEBUI_PORT $SPARK_MASTER >> $SPARK_WORKER_LOG/spark-worker.out
 


### PR DESCRIPTION
Spark 1.5.x had some issues (see https://github.com/apache/spark/pull/10714, https://issues.apache.org/jira/browse/SPARK-9844) that I ran into when using the `spark-java-template`.

This PR adds support for Spark v1.6.2 where these issues were resolved.