### PR TITLE
Write container logs to stdout

### DIFF
--- a/master/master.sh
+++ b/master/master.sh
@@ -10,5 +10,7 @@ mkdir -p $SPARK_MASTER_LOG
 
 export SPARK_HOME=/spark
 
+ln -sf /dev/stdout $SPARK_WORKER_LOG/spark-master.out
+
 cd /spark/bin && /spark/sbin/../bin/spark-class org.apache.spark.deploy.master.Master \
     --ip $SPARK_MASTER_HOST --port $SPARK_MASTER_PORT --webui-port $SPARK_MASTER_WEBUI_PORT >> $SPARK_MASTER_LOG/spark-master.out

--- a/worker/worker.sh
+++ b/worker/worker.sh
@@ -8,6 +8,7 @@ mkdir -p $SPARK_WORKER_LOG
 
 export SPARK_HOME=/spark
 
+ln -sf /dev/stdout $SPARK_WORKER_LOG/spark-worker.out
+
 /spark/sbin/../bin/spark-class org.apache.spark.deploy.worker.Worker \
     --webui-port $SPARK_WORKER_WEBUI_PORT $SPARK_MASTER >> $SPARK_WORKER_LOG/spark-worker.out
-


### PR DESCRIPTION
Hi, I think writing logs to stdout is proper approach for spark in containers. I've tried it on my local setup and it seems to work.