### PR TITLE
added support for submitting application jar by url

### DIFF
--- a/submit/submit.sh
+++ b/submit/submit.sh
@@ -3,11 +3,22 @@
 export SPARK_MASTER_URL=spark://${SPARK_MASTER_NAME}:${SPARK_MASTER_PORT}
 export SPARK_HOME=/spark
 
+function is_uri() {
+    regex='(https?|hdfs|file)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]'
+    if [[ $1 =~ $regex ]]
+    then 
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
+
 /wait-for-step.sh
 
 
 /execute-step.sh
-if [ -f "${SPARK_APPLICATION_JAR_LOCATION}" ]; then
+if [[ `is_uri $SPARK_APPLICATION_JAR_LOCATION`=="true" || -f "${SPARK_APPLICATION_JAR_LOCATION}" ]]; then
     echo "Submit application ${SPARK_APPLICATION_JAR_LOCATION} with main class ${SPARK_APPLICATION_MAIN_CLASS} to Spark master ${SPARK_MASTER_URL}"
     echo "Passing arguments ${SPARK_APPLICATION_ARGS}"
     /spark/bin/spark-submit \
@@ -16,7 +27,7 @@ if [ -f "${SPARK_APPLICATION_JAR_LOCATION}" ]; then
         ${SPARK_SUBMIT_ARGS} \
         ${SPARK_APPLICATION_JAR_LOCATION} ${SPARK_APPLICATION_ARGS}
 else
-    if [ -f "${SPARK_APPLICATION_PYTHON_LOCATION}" ]; then
+    if [[ `is_uri $SPARK_APPLICATION_PYTHON_LOCATION`=="true" || -f "${SPARK_APPLICATION_PYTHON_LOCATION}" ]]; then
         echo "Submit application ${SPARK_APPLICATION_PYTHON_LOCATION} to Spark master ${SPARK_MASTER_URL}"
         echo "Passing arguments ${SPARK_APPLICATION_ARGS}"
         PYSPARK_PYTHON=python3 /spark/bin/spark-submit \

--- a/submit/submit.sh
+++ b/submit/submit.sh
@@ -21,6 +21,7 @@ function is_uri() {
 if [[ `is_uri $SPARK_APPLICATION_JAR_LOCATION`=="true" || -f "${SPARK_APPLICATION_JAR_LOCATION}" ]]; then
     echo "Submit application ${SPARK_APPLICATION_JAR_LOCATION} with main class ${SPARK_APPLICATION_MAIN_CLASS} to Spark master ${SPARK_MASTER_URL}"
     echo "Passing arguments ${SPARK_APPLICATION_ARGS}"
+    # Uses eval so that parameters in quotes could be passed, relevant for --conf parameters
     $(eval /spark/bin/spark-submit \
         --class ${SPARK_APPLICATION_MAIN_CLASS} \
         --master ${SPARK_MASTER_URL} \

--- a/submit/submit.sh
+++ b/submit/submit.sh
@@ -21,16 +21,16 @@ function is_uri() {
 if [[ `is_uri $SPARK_APPLICATION_JAR_LOCATION`=="true" || -f "${SPARK_APPLICATION_JAR_LOCATION}" ]]; then
     echo "Submit application ${SPARK_APPLICATION_JAR_LOCATION} with main class ${SPARK_APPLICATION_MAIN_CLASS} to Spark master ${SPARK_MASTER_URL}"
     echo "Passing arguments ${SPARK_APPLICATION_ARGS}"
-    /spark/bin/spark-submit \
+    $(eval /spark/bin/spark-submit \
         --class ${SPARK_APPLICATION_MAIN_CLASS} \
         --master ${SPARK_MASTER_URL} \
         ${SPARK_SUBMIT_ARGS} \
-        ${SPARK_APPLICATION_JAR_LOCATION} ${SPARK_APPLICATION_ARGS}
+        ${SPARK_APPLICATION_JAR_LOCATION} ${SPARK_APPLICATION_ARGS})
 else
     if [[ `is_uri $SPARK_APPLICATION_PYTHON_LOCATION`=="true" || -f "${SPARK_APPLICATION_PYTHON_LOCATION}" ]]; then
         echo "Submit application ${SPARK_APPLICATION_PYTHON_LOCATION} to Spark master ${SPARK_MASTER_URL}"
         echo "Passing arguments ${SPARK_APPLICATION_ARGS}"
-        PYSPARK_PYTHON=python3 /spark/bin/spark-submit \
+        PYSPARK_PYTHON=python3  /spark/bin/spark-submit \
             --master ${SPARK_MASTER_URL} \
             ${SPARK_SUBMIT_ARGS} \
             ${SPARK_APPLICATION_PYTHON_LOCATION} ${SPARK_APPLICATION_ARGS}


### PR DESCRIPTION
Added support for submitting a jar by specifying a url instead of jar.
The usage:
docker run --rm -it \
    -e ENABLE_INIT_DAEMON=false \
    -e SPARK_MASTER_NAME=$SPARK_MASTER \
    -e SPARK_MASTER_PORT=7077 \
    -e "SPARK_APPLICATION_JAR_LOCATION=http://s3-bucket/my.jar" \
    -e SPARK_APPLICATION_MAIN_CLASS=com.armis.aggregations.Main \
    spark-submit:spark-2.3.2-hadoop2.7