### PR TITLE
Added support for spark 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Docker images to:
 * Build Spark applications in Java, Scala or Python to run on a Spark cluster
 
 Currently supported versions:
+* Spark 2.4.1 for Hadoop 2.7+ with OpenJDK 8
 * Spark 2.4.0 for Hadoop 2.8 with OpenJDK 8 and Scala 2.12
 * Spark 2.4.0 for Hadoop 2.7+ with OpenJDK 8
 * Spark 2.3.2 for Hadoop 2.7+ with OpenJDK 8
@@ -33,7 +34,7 @@ Currently supported versions:
 Add the following services to your `docker-compose.yml` to integrate a Spark master and Spark worker in [your BDE pipeline](https://github.com/big-data-europe/app-bde-pipeline):
 ```yml
 spark-master:
-  image: bde2020/spark-master:2.4.0-hadoop2.7
+  image: bde2020/spark-master:2.4.1-hadoop2.7
   container_name: spark-master
   ports:
     - "8080:8080"
@@ -42,7 +43,7 @@ spark-master:
     - INIT_DAEMON_STEP=setup_spark
     - "constraint:node==<yourmasternode>"
 spark-worker-1:
-  image: bde2020/spark-worker:2.4.0-hadoop2.7
+  image: bde2020/spark-worker:2.4.1-hadoop2.7
   container_name: spark-worker-1
   depends_on:
     - spark-master
@@ -52,7 +53,7 @@ spark-worker-1:
     - "SPARK_MASTER=spark://spark-master:7077"
     - "constraint:node==<yourworkernode>"
 spark-worker-2:
-  image: bde2020/spark-worker:2.4.0-hadoop2.7
+  image: bde2020/spark-worker:2.4.1-hadoop2.7
   container_name: spark-worker-2
   depends_on:
     - spark-master
@@ -68,12 +69,12 @@ Make sure to fill in the `INIT_DAEMON_STEP` as configured in your pipeline.
 ### Spark Master
 To start a Spark master:
 
-    docker run --name spark-master -h spark-master -e ENABLE_INIT_DAEMON=false -d bde2020/spark-master:2.4.0-hadoop2.7
+    docker run --name spark-master -h spark-master -e ENABLE_INIT_DAEMON=false -d bde2020/spark-master:2.4.1-hadoop2.7
 
 ### Spark Worker
 To start a Spark worker:
 
-    docker run --name spark-worker-1 --link spark-master:spark-master -e ENABLE_INIT_DAEMON=false -d bde2020/spark-worker:2.4.0-hadoop2.7
+    docker run --name spark-worker-1 --link spark-master:spark-master -e ENABLE_INIT_DAEMON=false -d bde2020/spark-worker:2.4.1-hadoop2.7
 
 ## Launch a Spark application
 Building and running your Spark application on top of the Spark cluster is as simple as extending a template Docker image. Check the template's README for further documentation.

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,7 +7,7 @@ ENV ENABLE_INIT_DAEMON true
 ENV INIT_DAEMON_BASE_URI http://identifier/init-daemon
 ENV INIT_DAEMON_STEP spark_master_init
 
-ENV SPARK_VERSION=2.4.0
+ENV SPARK_VERSION=2.4.1
 ENV HADOOP_VERSION=2.7
 
 COPY wait-for-step.sh /

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TAG=2.4.0-hadoop2.7
+TAG=2.4.1-hadoop2.7
 
 build() {
     NAME=$1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   spark-master:
-    image: bde2020/spark-master:2.4.0-hadoop2.7
+    image: bde2020/spark-master:2.4.1-hadoop2.7
     container_name: spark-master
     ports:
       - "8080:8080"
@@ -9,7 +9,7 @@ services:
     environment:
       - INIT_DAEMON_STEP=setup_spark
   spark-worker-1:
-    image: bde2020/spark-worker:2.4.0-hadoop2.7
+    image: bde2020/spark-worker:2.4.1-hadoop2.7
     container_name: spark-worker-1
     depends_on:
       - spark-master

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,4 +1,4 @@
-FROM bde2020/spark-base:2.4.0-hadoop2.7
+FROM bde2020/spark-base:2.4.1-hadoop2.7
 
 MAINTAINER Erika Pauwels <erika.pauwels@tenforce.com>
 MAINTAINER Gezim Sejdiu <g.sejdiu@gmail.com>

--- a/submit/Dockerfile
+++ b/submit/Dockerfile
@@ -1,4 +1,4 @@
-FROM bde2020/spark-base:2.4.0-hadoop2.7
+FROM bde2020/spark-base:2.4.1-hadoop2.7
 
 MAINTAINER Erika Pauwels <erika.pauwels@tenforce.com>
 MAINTAINER Gezim Sejdiu <g.sejdiu@gmail.com>

--- a/template/java/Dockerfile
+++ b/template/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM bde2020/spark-submit:2.4.0-hadoop2.7
+FROM bde2020/spark-submit:2.4.1-hadoop2.7
 
 MAINTAINER Erika Pauwels <erika.pauwels@tenforce.com>
 MAINTAINER Gezim Sejdiu <g.sejdiu@gmail.com>

--- a/template/python/Dockerfile
+++ b/template/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM bde2020/spark-submit:2.4.0-hadoop2.7
+FROM bde2020/spark-submit:2.4.1-hadoop2.7
 
 MAINTAINER Cecile Tonglet <cecile.tonglet@tenforce.com>
 

--- a/template/scala/Dockerfile
+++ b/template/scala/Dockerfile
@@ -1,4 +1,4 @@
-FROM bde2020/spark-submit:2.4.0-hadoop2.7
+FROM bde2020/spark-submit:2.4.1-hadoop2.7
 
 MAINTAINER Cecile Tonglet <cecile.tonglet@tenforce.com>
 MAINTAINER Gezim Sejdiu <g.sejdiu@gmail.com>

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM bde2020/spark-base:2.4.0-hadoop2.7
+FROM bde2020/spark-base:2.4.1-hadoop2.7
 
 MAINTAINER Erika Pauwels <erika.pauwels@tenforce.com>
 MAINTAINER Gezim Sejdiu <g.sejdiu@gmail.com>


### PR DESCRIPTION
This adds support for Spark 2.4.1 (https://github.com/big-data-europe/docker-spark/issues/69). Since at the moment master branch deploys Spark 2.4.0 this should be used as latest instead.