### PR TITLE
outdated openjdk8 changed to quick and modern graalvm

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PropertiesComponent">
+    <property name="nodejs_interpreter_path.stuck_in_default_project" value="undefined stuck path" />
+    <property name="nodejs_npm_path_reset_for_default_project" value="true" />
+  </component>
+  <component name="SbtLocalSettings">
+    <option name="projectSyncType">
+      <map>
+        <entry key="/data/sources/PWM" value="PREVIEW" />
+        <entry key="/data/sources/adam-playground" value="PREVIEW" />
+        <entry key="/data/sources/cromwell-client" value="PREVIEW" />
+        <entry key="/data/sources/geo-fetch" value="PREVIEW" />
+        <entry key="/data/sources/spark-extensions" value="PREVIEW" />
+      </map>
+    </option>
+  </component>
+</project>

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -16,7 +16,19 @@ COPY finish-step.sh /
 
 #COPY bde-spark.css /css/org/apache/spark/ui/static/timeline-view.css
 
-RUN apk add --no-cache curl bash openjdk8-jre python3 py-pip nss \
+ENV GLIBC_VERSION=2.29-r0 \
+    GRAALVM_VERSION=19.0.2 \
+    JAVA_HOME=/usr/lib/jvm/graalvm-ce-19.0.2 \
+    PATH=/usr/lib/jvm/graalvm-ce-19.0.2/bin:$PATH
+
+RUN apk --no-cache add ca-certificates wget gcc zlib zlib-dev libc-dev bash
+
+RUN mkdir /usr/lib/jvm \
+    && wget "https://github.com/oracle/graal/releases/download/vm-${GRAALVM_VERSION}/graalvm-ce-linux-amd64-${GRAALVM_VERSION}.tar.gz" \
+    && tar -zxC /usr/lib/jvm -f graalvm-ce-linux-amd64-${GRAALVM_VERSION}.tar.gz \
+    && rm -f graalvm-ce-linux-amd64-${GRAALVM_VERSION}.tar.gz
+
+RUN apk add --no-cache curl bash python3 py-pip nss \
       && chmod +x *.sh \
       && wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
       && tar -xvzf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \


### PR DESCRIPTION
Openjdk8 is old, slow and heap-heavy. Graalvm increases performance by 30-50% for Scala Spark applications.