### PR TITLE
fix python template DockerFile 

### DIFF
--- a/template/python/Dockerfile
+++ b/template/python/Dockerfile
@@ -2,14 +2,14 @@ FROM bde2020/spark-submit:2.4.4-hadoop2.7
 
 LABEL maintainer="Gezim Sejdiu <g.sejdiu@gmail.com>, Giannis Mouchakis <gmouchakis@gmail.com>"
 
+# Copy the source code
+COPY . /app
+
 COPY template.sh /
 
 # Copy the requirements.txt first, for separate dependency resolving and downloading
-ONBUILD COPY requirements.txt /app/
-ONBUILD RUN cd /app \
+COPY requirements.txt /app/
+RUN cd /app \
       && pip3 install -r requirements.txt
-
-# Copy the source code
-ONBUILD COPY . /app
 
 CMD ["/bin/bash", "/template.sh"]


### PR DESCRIPTION
The pull request contains changes to make the python template working properly. 

I'm planning to add a sample app that will be using python template but I don't know where to place it, some ideas? 

Related to  issue #56 