### PR TITLE
Should export SPARK_HOME before loading /spark/sbin/spark-config.sh

### DIFF
--- a/master/master.sh
+++ b/master/master.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export SPARK_HOME=/spark
+
 export SPARK_MASTER_HOST=`hostname`
 
 . "/spark/sbin/spark-config.sh"
@@ -7,8 +9,6 @@ export SPARK_MASTER_HOST=`hostname`
 . "/spark/bin/load-spark-env.sh"
 
 mkdir -p $SPARK_MASTER_LOG
-
-export SPARK_HOME=/spark
 
 ln -sf /dev/stdout $SPARK_MASTER_LOG/spark-master.out
 

--- a/worker/worker.sh
+++ b/worker/worker.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
+export SPARK_HOME=/spark
+
 . "/spark/sbin/spark-config.sh"
 
 . "/spark/bin/load-spark-env.sh"
 
 mkdir -p $SPARK_WORKER_LOG
-
-export SPARK_HOME=/spark
 
 ln -sf /dev/stdout $SPARK_WORKER_LOG/spark-worker.out
 


### PR DESCRIPTION
File /spark/sbin/spark-config.sh needs SPARK_HOME, if not defined, it will define a bad one and spawn a java process like:

`/usr/lib/jvm/java-1.8-openjdk/jre/bin/java -cp ///conf/:/spark/jars/* -Xmx1g ...`

Here `///conf` is a wrong path, it should be `/spark/conf`.
