### PR TITLE
Revert "fix python template DockerFile "

### DIFF
--- a/template/python/Dockerfile
+++ b/template/python/Dockerfile
@@ -2,14 +2,14 @@ FROM bde2020/spark-submit:3.1.1-hadoop3.2
 
 LABEL maintainer="Gezim Sejdiu <g.sejdiu@gmail.com>, Giannis Mouchakis <gmouchakis@gmail.com>"
 
-# Copy the source code
-COPY . /app
-
 COPY template.sh /
 
 # Copy the requirements.txt first, for separate dependency resolving and downloading
-COPY requirements.txt /app/
-RUN cd /app \
+ONBUILD COPY requirements.txt /app/
+ONBUILD RUN cd /app \
       && pip3 install -r requirements.txt
+
+# Copy the source code
+ONBUILD COPY . /app
 
 CMD ["/bin/bash", "/template.sh"]


### PR DESCRIPTION
Reverts big-data-europe/docker-spark#87

Yeah, I missed your change :( and have to revert the change. Mainly we keep `ONBUIL` flags as this will serve as a base image for later when the application will use this a a base image, as obviously we can't install any requirements without knowing what application needs.

From the Docker documentation:
> The ONBUILD instruction adds to the image a trigger instruction to be executed at a later time, when the image is used as the base for another build. The trigger will be executed in the context of the downstream build, as if it had been inserted immediately after the FROM instruction in the downstream Dockerfile.


Thanks again for your contribution.

Best,