### PR TITLE
Fix python template/example for spark

### DIFF
--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -17,5 +17,5 @@ To run the application, execute the following steps:
     ```
 3. Run the Docker container:
     ```bash
-    docker run --rm --network dockerspark_default --name pyspark-example bde2020/spark-python-example:3.2.0-hadoop3.2
+    docker run --rm --network docker-spark_default --name pyspark-example bde2020/spark-python-example:3.2.0-hadoop3.2
     ```

--- a/template/python/README.md
+++ b/template/python/README.md
@@ -19,7 +19,7 @@ project, so make sure you have a `requirements.txt` file in the root of your app
 4. Build and run the image
 ```
 docker build --rm -t bde/spark-app .
-docker run --name my-spark-app -e ENABLE_INIT_DAEMON=false --link spark-master:spark-master --net dockerspark_default -d bde/spark-app
+docker run --name my-spark-app -e ENABLE_INIT_DAEMON=false --link spark-master:spark-master --net docker-spark_default -d bde/spark-app
 ```
 
 The sources in the project folder will be automatically added to `/app` if you directly extend the Spark Python template image. Otherwise you will have to add the sources by yourself in your Dockerfile with the command:


### PR DESCRIPTION
I’m not sure if it’s my problem, but when I use the `docker network ls` command, I didn’t find `dockerspark_defalut `but `docker-spark_default`.