### PR TITLE
Update the network name in the README

### DIFF
--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -17,5 +17,5 @@ To run the application, execute the following steps:
     ```
 3. Run the Docker container:
     ```bash
-    docker run --rm --network dockerspark_default --name pyspark-example bde2020/spark-python-example:3.3.0-hadoop3.3
+    docker run --rm --network docker-spark_default --name pyspark-example bde2020/spark-python-example:3.3.0-hadoop3.3
     ```


### PR DESCRIPTION
Given that the repo name is `docker-spark`, the default network name here is incorrect.

@GezimSejdiu please review